### PR TITLE
Puts all the defined functions in a module

### DIFF
--- a/src/code_gen.ml
+++ b/src/code_gen.ml
@@ -6,10 +6,10 @@ let loc = Location.none
 
 (** {2 Names handling} *)
 
-let guess_zip_name name = "zip_" ^ name
-let guess_unzip_name name = "unzip_" ^ name
-let guess_goup_name name = "go_up_" ^ name
-let guess_view_name name = "view_" ^ name
+let guess_zip_name _name = "zip"
+let guess_unzip_name _name = "unzip"
+let guess_go_up_name _name = "go_up"
+let guess_view_name _name = "view"
 
 (** {2} Helpers *)
 
@@ -76,7 +76,7 @@ let go_up typ derivative =
       (make_constructor_expr ~on_hole:(fun _ -> [%expr t]) (original_constructor_name cons) args)
   in
   let value =
-    let fun_name = guess_goup_name typ.name in
+    let fun_name = guess_go_up_name typ.name in
     let ancestor_match = Exp.match_
         [%expr derivative]
         (List.map generate_match_case (variants derivative.def))
@@ -136,7 +136,7 @@ let unzip typ =
   let unzip_name = guess_unzip_name typ.name in
   let fun_pat = Pat.var (Location.mknoloc unzip_name) in
   let fun_expr = Exp.ident (lid unzip_name) in
-  let go_up_name = Exp.ident (guess_goup_name typ.name |> lid) in
+  let go_up_name = Exp.ident (guess_go_up_name typ.name |> lid) in
   [%stri let rec [%p fun_pat] = fun zipper ->
       match snd zipper with
       | [] -> fst zipper

--- a/src/code_gen.ml
+++ b/src/code_gen.ml
@@ -83,10 +83,10 @@ let go_up typ derivative =
     in
     Vb.mk (Pat.var (fun_name |> Location.mknoloc))
       [%expr fun (t, ancestors) -> match ancestors with
-        | [] -> invalid_arg [%e Exp.constant (Const.string fun_name)]
+        | [] -> None
         | derivative :: ancestors ->
           let tree = [%e ancestor_match] in
-          tree, ancestors]
+          Some (tree, ancestors)]
   in
   Str.value Asttypes.Nonrecursive [value]
 
@@ -138,6 +138,6 @@ let unzip typ =
   let fun_expr = Exp.ident (lid unzip_name) in
   let go_up_name = Exp.ident (guess_go_up_name typ.name |> lid) in
   [%stri let rec [%p fun_pat] = fun zipper ->
-      match snd zipper with
-      | [] -> fst zipper
-      | _ -> [%e fun_expr] ([%e go_up_name] zipper)]
+      match [%e go_up_name] zipper with
+      | None -> fst zipper
+      | Some zipper -> [%e fun_expr] zipper]

--- a/src/ppx_deriving_zipper.ml
+++ b/src/ppx_deriving_zipper.ml
@@ -1,7 +1,10 @@
 open Ast_helper
 open Parsetree
 
-let wrap_decl ~is_derivative d = Str.type_ Asttypes.Recursive [Ztype.to_decl ~is_derivative d]
+let wrap_decl ?(non_rec=true) ~is_derivative d =
+  Str.type_
+    Asttypes.(if non_rec then Nonrecursive else Recursive)
+    [Ztype.to_decl ~is_derivative d]
 
 let mangle_type_decl_to_module ?(fixpoint="t") affix type_ =
   let cap = String.capitalize_ascii in

--- a/src/ppx_deriving_zipper.ml
+++ b/src/ppx_deriving_zipper.ml
@@ -3,6 +3,19 @@ open Parsetree
 
 let wrap_decl ~is_derivative d = Str.type_ Asttypes.Recursive [Ztype.to_decl ~is_derivative d]
 
+let mangle_type_decl_to_module ?(fixpoint="t") affix type_ =
+  let cap = String.capitalize_ascii in
+  (match affix with
+   | `Prefix prefix | `PrefixSuffix (prefix, _) -> cap prefix
+   | _ -> "")
+  ^
+  (let type_ = type_.ptype_name.txt in
+   if type_ = fixpoint then "" else cap type_)
+  ^
+  (match affix with
+   | `Suffix suffix | `PrefixSuffix (_, suffix) -> cap suffix
+   | _ -> "")
+
 let type_decl_str ~options ~path =
   ignore options;
   ignore path;
@@ -21,16 +34,21 @@ let type_decl_str ~options ~path =
       let loc = Location.none in
       [%stri type 'a thunk = unit -> 'a]
     in
+    let in_module name str = Str.module_ (Mb.mk name (Mod.structure str)) in
     [
-      thunk;
-      wrap_decl ~is_derivative:true derivative;
-      wrap_decl ~is_derivative:false ancestor;
-      wrap_decl ~is_derivative:false zipper;
-      wrap_decl ~is_derivative:false view;
-      Code_gen.zip decl;
-      Code_gen.go_up decl derivative;
-      Code_gen.unzip decl;
-      Code_gen.view decl;
+      in_module
+        (Location.mknoloc (mangle_type_decl_to_module (`Suffix "zipper") type_decl))
+        [
+          thunk;
+          wrap_decl ~is_derivative:true derivative;
+          wrap_decl ~is_derivative:false ancestor;
+          wrap_decl ~is_derivative:false zipper;
+          wrap_decl ~is_derivative:false view;
+          Code_gen.zip decl;
+          Code_gen.go_up decl derivative;
+          Code_gen.unzip decl;
+          Code_gen.view decl;
+        ]
     ]
   | _ -> assert false
 

--- a/src/type_gen.ml
+++ b/src/type_gen.ml
@@ -18,10 +18,10 @@ let subst t = function
 
 (** {2 Names handling} *)
 
-let guess_derivative_name name = name ^ "_diff"
-let guess_ancestor_name name = name ^ "_ancestor"
-let guess_zipper_name name = name ^ "_zipper"
-let guess_view_name name = name ^ "_view"
+let guess_derivative_name _name = "diff"
+let guess_ancestor_name _name = "ancestor"
+let guess_zipper_name _name = "t"
+let guess_view_name _name = "view"
 let guess_view_constr_name name = "Z" ^ name
 
 (** {2 Type generation} *)

--- a/test/test.ml
+++ b/test/test.ml
@@ -33,9 +33,9 @@ let a =
     )
   )
 
-
 let () =
-  let rec go_bot_left z = match view_tree z with
+  let rec go_bot_left z =
+    match TreeZipper.view z with
     | ZNil -> z
     | ZUNode (f, child) ->
       Format.printf "%F@." f;
@@ -44,8 +44,8 @@ let () =
       Format.printf "%d@." n;
       go_bot_left (left ())
   in
-  let (_, ancestors) = go_bot_left (zip_tree a) in
-  let tree = unzip_tree (UNode (42.42, Nil), ancestors) in
+  let (_, ancestors) = go_bot_left (TreeZipper.zip a) in
+  let tree = TreeZipper.unzip (UNode (42.42, Nil), ancestors) in
   Format.printf "%a@." pp_tree tree
 
 let () = print_endline "test.ml OK"


### PR DESCRIPTION
- Avoids polluting the namespace with hundreds of functions.
- Makes the `guess_name` functions trivial because only the module name becomes necessary to craft.

wdyt @Kerl13?