### PR TITLE
Only use major version numbers in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Clone Repository
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@v3
 
       - name: Install Nix
         uses: cachix/install-nix-action@v20


### PR DESCRIPTION
reduces the spam from dependabot